### PR TITLE
Server image now uses PAT to pull repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ The server production docker image builds the production version of the bundle, 
 
 #### Build Args
 
-This docker file allows you to pass in build time arguments to change the environment the server bundle is being built with. There are two build arguments that are **required**: `INFURA_ID` and `JWT_SECRET`
+This docker file allows you to pass in build time arguments to change the environment the server bundle is being built with. There are tree build arguments that are **required**: `INFURA_ID`, `JWT_SECRET` and your github token passed into `GH_PAT`
 
 Build args:
+- `GH_PAT`: the GitHub Personal Access Token **required** to authenticate and pull information from our private repo _(Note: you **have to** supply this yourself, otherwise it won't work)_.
 - `INFURA_ID`: The infura project id we are using as a provider. This is **required** as we don't provide a default for it in the `Dockerfile`. See the _Infura Dashboard_ for the correct project id
 - `JWT_SECRET`: The secret string to use for authentication. [More on JWT here](https://stackoverflow.com/a/28503265)
 - `NETWORK`: Network value to be passed to the environment, defaults to `goerli`
@@ -58,7 +59,7 @@ Build args:
 
 Usage example:
 ```bash
-docker build --build-arg INFURA_ID='XXX' --build-arg JWT_SERCRET='this-should-be-really-really-secret' --no-cache .
+docker build --build-arg GH_PAT='XXX' --build-arg INFURA_ID='XXX' --build-arg JWT_SERCRET='this-should-be-really-really-secret' --no-cache .
 ```
 
 #### Building from a different branch / commit hash

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The server production docker image builds the production version of the bundle, 
 
 #### Build Args
 
-This docker file allows you to pass in build time arguments to change the environment the server bundle is being built with. There are tree build arguments that are **required**: `INFURA_ID`, `JWT_SECRET` and your github token passed into `GH_PAT`
+This docker file allows you to pass in build time arguments to change the environment the server bundle is being built with. There are three build arguments that are **required**: `INFURA_ID`, `JWT_SECRET` and your github token passed into `GH_PAT`
 
 Build args:
 - `GH_PAT`: the GitHub Personal Access Token **required** to authenticate and pull information from our private repo _(Note: you **have to** supply this yourself, otherwise it won't work)_.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,12 +1,18 @@
 FROM node:10.16
 
+# @NOTE This Dockerfile pulls in a private repository
+# In order to accomplish this, it makes use of a GH Personal Access Token:
+# https://github.com/settings/tokens (Make sure you have the `repo` scope, ...and only that)
+
 # @NOTE Declare the commit hash build variable, so that it gets picked up by the conditional
 ARG COMMIT_HASH
 ARG JWT_SECRET
 ARG INFURA_ID
+ARG GH_PAT
 
 RUN if [ -z "$JWT_SECRET" ]; then echo "JWT_SECRET build argument was NOT SET. Stopping..."; exit 1; else : ; fi
 RUN if [ -z "$INFURA_ID" ]; then echo "INFURA_ID build argument was NOT SET. Stopping..."; exit 1; else : ; fi
+RUN if [ -z "$GH_PAT" ]; then echo "GH_PAT build argument was NOT SET. Stopping..."; exit 1; else : ; fi
 
 # Build arguments that have default values
 ARG NETWORK_CONTRACT_ADDRESS=0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B
@@ -42,7 +48,7 @@ RUN wget https://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.2/multiv
 RUN dpkg -i mongodb-org-server_4.2.2_amd64.deb
 
 # Clone the repo
-RUN git clone "https://github.com/JoinColony/colonyServer.git"
+RUN git clone "https://$GH_PAT@github.com/JoinColony/colonyServer.git"
 WORKDIR /colonyServer
 RUN if [ ! -z "$COMMIT_HASH" ]; then git checkout $COMMIT_HASH; fi
 


### PR DESCRIPTION
This PR introduces the `GH_PAT` build argument to the server image so that it's now capable, again, to pull the repo data, after that repository has been made private.

It uses the same logic as the (d)app image had in the previous version, but with an added check that prevents the build from starting if the Personal Access Token has not been provided beforehand.