### PR TITLE
Add server image Ethplorer ARG

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Build args:
 - `APOLLO_PORT`: The port the server will be accessible on, defaults to `3000`
 - `DISABLE_EXPIRY_CHECK`: Disable the expiry logic check. Defaults to `false`. **Do not** set to `true` while using it in production.
 - `DISABLE_AUTH_CHECK`: Disable the authentication logic check. Defaults to `false`. **Do not** set to `true` while using it in production.
-
+- `ETHPLORER_API_KEY`: Pass in the API for [Ethplorer](https://ethplorer.io/). Defaults to `freekey`, which is [pretty limited](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#freekey-limits).
 Usage example:
 ```bash
 docker build --build-arg GH_PAT='XXX' --build-arg INFURA_ID='XXX' --build-arg JWT_SERCRET='this-should-be-really-really-secret' --no-cache .

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,6 +20,7 @@ ARG APOLLO_PORT=3000
 ARG NETWORK=goerli
 ARG DISABLE_EXPIRY_CHECK=false
 ARG DISABLE_AUTH_CHECK=false
+ARG ETHPLORER_API_KEY=freekey
 
 # Update the apt cache
 RUN apt-get clean
@@ -61,7 +62,8 @@ RUN echo "DB_NAME=colonyCentralizedMetadata\n" \
   "NETWORK=$NETWORK\n" \
   "NETWORK_CONTRACT_ADDRESS=$NETWORK_CONTRACT_ADDRESS\n" \
   "INFURA_ID=$INFURA_ID\n" \
-  "APOLLO_PORT=$APOLLO_PORT\n" > .env
+  "APOLLO_PORT=$APOLLO_PORT\n" \
+  "ETHPLORER_API_KEY=$ETHPLORER_API_KEY\n" > .env
 
 # Setup the server modules
 RUN npm i


### PR DESCRIPTION
This PR does what it says on the tin, it adds a new ENV variable, passed through a build-time ARG to the server image, which passes in the API for [ethplorer](https://ethplorer.io/).