### PR TITLE
Remove App/Server images build ENV arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,17 @@ Colony docker images for hub auto-builds
 ### circleci-cypress
 An image based on circleci/node which also contains the cypress testing dependencies
 
-### dapp
+### aapp
 
-The dApp production docker image builds the production version of the bundle, moves it to separate folder, and serves it via a simple `nginx` server on port `80`
+The App production docker image builds the production version of the bundle, moves it to separate folder, and serves it via a simple `nginx` server on port `80`
 
 The `Dockerfile` just needs to be built, and run. The `nginx` service `CMD` will keep the container alive.
 
-#### Build Args
-
-This docker file allows you to pass in build time arguments to change the environment the dApp's bundle is being built with. The only one of these that is **required** is the `INFURA_ID` one, without which, you won't be able to use the provider.
-
-Build args:
-- `INFURA_ID`: The infura project id we are using in the dApp. This is **required** as we don't provide a default for it in the `Dockerfile`. See the _Infura Dashboard_ for the correct project id
-- `LOADER`: Loader value to be passed to the dApp's environment, defaults to `network`
-- `NETWORK`: Network value to be passed to the dApp's environment, defaults to `goerli`
-- `VERBOSE`: If the dApp's console output should be verbose or not, defaults to `false`
-- `COLONY_NETWORK_ENS_NAME`: The ENS name the dApp should use for users and colonies, defaults to `joincolony.eth`
-- `SERVER_ENDPOINT`: Address of the appollo server to connect to, defaults to `http://127.0.0.1:3000`
+While the app itself uses ENV variables, they are expected to be set in the envrinment that this image will run in. For the required ones, check the [app repository](https://github.com/JoinColony/colonyDapp).
 
 Usage example:
 ```bash
-docker build --build-arg INFURA_ID='XXX' --build-arg COLONY_NETWORK_ENS_NAME='joincolony.test' --build-arg VERBOSE='true' --no-cache .
+docker build --no-cache .
 ```
 
 #### Building from a different branch / commit hash
@@ -45,21 +35,16 @@ The server production docker image builds the production version of the bundle, 
 
 #### Build Args
 
-This docker file allows you to pass in build time arguments to change the environment the server bundle is being built with. There are three build arguments that are **required**: `INFURA_ID`, `JWT_SECRET` and your github token passed into `GH_PAT`
+This docker file allows you to pass in build time arguments to change the environment the server bundle is being built with. There is only one build arguments that is **required**: your github token passed into `GH_PAT`
 
 Build args:
 - `GH_PAT`: the GitHub Personal Access Token **required** to authenticate and pull information from our private repo _(Note: you **have to** supply this yourself, otherwise it won't work)_.
-- `INFURA_ID`: The infura project id we are using as a provider. This is **required** as we don't provide a default for it in the `Dockerfile`. See the _Infura Dashboard_ for the correct project id
-- `JWT_SECRET`: The secret string to use for authentication. [More on JWT here](https://stackoverflow.com/a/28503265)
-- `NETWORK`: Network value to be passed to the environment, defaults to `goerli`
-- `NETWORK_CONTRACT_ADDRESS`: The address of the ETHRouter contract deployed for the current network. Defaults to _(as the `NETWORK` above)_ to the `goerli` deployed one: `0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B`
-- `APOLLO_PORT`: The port the server will be accessible on, defaults to `3000`
-- `DISABLE_EXPIRY_CHECK`: Disable the expiry logic check. Defaults to `false`. **Do not** set to `true` while using it in production.
-- `DISABLE_AUTH_CHECK`: Disable the authentication logic check. Defaults to `false`. **Do not** set to `true` while using it in production.
-- `ETHPLORER_API_KEY`: Pass in the API for [Ethplorer](https://ethplorer.io/). Defaults to `freekey`, which is [pretty limited](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API#freekey-limits).
+
+While there are _other_ ENV variables that are needed for the server itself to function properly, they are expected to be set in the envrinment that this image will run in. For the required ones, check the [server repository](https://github.com/JoinColony/colonyServer).
+
 Usage example:
 ```bash
-docker build --build-arg GH_PAT='XXX' --build-arg INFURA_ID='XXX' --build-arg JWT_SERCRET='this-should-be-really-really-secret' --no-cache .
+docker build --build-arg GH_PAT='XXX' --no-cache .
 ```
 
 #### Building from a different branch / commit hash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Colony docker images for hub auto-builds
 ### circleci-cypress
 An image based on circleci/node which also contains the cypress testing dependencies
 
-### aapp
+### app
 
 The App production docker image builds the production version of the bundle, moves it to separate folder, and serves it via a simple `nginx` server on port `80`
 

--- a/dapp/Dockerfile
+++ b/dapp/Dockerfile
@@ -1,24 +1,7 @@
 FROM node:10.16.3
 
-# @NOTE This Dockerfile pulls in a private repository
-# In order to accomplish this, it makes use of a GH Personal Access Token:
-# https://github.com/settings/tokens (Make sure you have the `repo` scope, ...and only that)
-#
-# @NOTE This is required to be set at build time, otherwise calls to infura might fail
-# Also, due to security considerations, we're not storing it here
-#
-# Eg: docker build --build-arg INFURA_ID='XXX' .
-ARG INFURA_ID
 # @NOTE Declare the commit hash build variable, so that it gets picked up by the conditional
 ARG COMMIT_HASH
-
-# Make the dapp's ENV values to have the option to be set at build time
-# But fall back to a default
-ARG LOADER=network
-ARG NETWORK=goerli
-ARG VERBOSE=false
-ARG COLONY_NETWORK_ENS_NAME=joincolony.eth
-ARG SERVER_ENDPOINT=http://127.0.0.1:3000
 
 # @FIX Allow the nginx service to start at build time, so that the installation will work
 # See: https://askubuntu.com/questions/365911/why-the-services-do-not-start-at-installation
@@ -50,14 +33,6 @@ RUN if [ ! -z "$COMMIT_HASH" ]; then git checkout $COMMIT_HASH; fi
 # Install node_modules
 RUN yarn
 
-# Setup the repo's ENV file
-RUN echo "LOADER=$LOADER\n" \
-        "INFURA_ID=$INFURA_ID\n" \
-        "NETWORK=$NETWORK\n" \
-        "VERBOSE=$VERBOSE\n" \
-        "COLONY_NETWORK_ENS_NAME=$COLONY_NETWORK_ENS_NAME\n" \
-        "SERVER_ENDPOINT=$SERVER_ENDPOINT\n" > .env
-
 # Build the production bundle
 RUN yarn webpack:build:prod
 
@@ -83,8 +58,20 @@ RUN echo "server {\n" \
 # Expose the HTTP port
 EXPOSE 80
 
+# @NOTE Hack!
+# We replace the environment variables in the built bundle with the ones declared in the kubernetes config
+# This is necessary since we aren't in a actual node process, they're just files served by nginx
+# Doing it like this allows us to use the same image for different deployments
+RUN echo "sed -i \"s|e.env.SERVER_ENDPOINT|\\\"\$SERVER_ENDPOINT\\\"|g\" *.js" \
+        "&& sed -i \"s/e.env.LOADER/\\\"\$LOADER\\\"/g\" *.js" \
+        "&& sed -i \"s/e.env.NETWORK/\\\"\$NETWORK\\\"/g\" *.js" \
+        "&& sed -i \"s/e.env.VERBOSE/\\\"\$VERBOSE\\\"/g\" *.js" \
+        "&& sed -i \"s/e.env.COLONY_NETWORK_ENS_NAME/\\\"\$COLONY_NETWORK_ENS_NAME\\\"/g\" *.js" \
+        "&& sed -i \"s/e.env.INFURA_ID/\\\"\$INFURA_ID\\\"/g\" *.js" \
+        " && nginx -g 'daemon off;'" > ./run.sh
+RUN chmod +x ./run.sh
+
 # @NOTE Run the actual command, rather then the service
 # so that the docker container won't exit
-CMD ["nginx", "-g", "daemon off;"]
-
+CMD ./run.sh
 # READY TO GO !

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,24 +3,12 @@ FROM node:10.16
 # @NOTE This Dockerfile pulls in a private repository
 # In order to accomplish this, it makes use of a GH Personal Access Token:
 # https://github.com/settings/tokens (Make sure you have the `repo` scope, ...and only that)
+ARG GH_PAT
 
 # @NOTE Declare the commit hash build variable, so that it gets picked up by the conditional
 ARG COMMIT_HASH
-ARG JWT_SECRET
-ARG INFURA_ID
-ARG GH_PAT
 
-RUN if [ -z "$JWT_SECRET" ]; then echo "JWT_SECRET build argument was NOT SET. Stopping..."; exit 1; else : ; fi
-RUN if [ -z "$INFURA_ID" ]; then echo "INFURA_ID build argument was NOT SET. Stopping..."; exit 1; else : ; fi
 RUN if [ -z "$GH_PAT" ]; then echo "GH_PAT build argument was NOT SET. Stopping..."; exit 1; else : ; fi
-
-# Build arguments that have default values
-ARG NETWORK_CONTRACT_ADDRESS=0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B
-ARG APOLLO_PORT=3000
-ARG NETWORK=goerli
-ARG DISABLE_EXPIRY_CHECK=false
-ARG DISABLE_AUTH_CHECK=false
-ARG ETHPLORER_API_KEY=freekey
 
 # Update the apt cache
 RUN apt-get clean
@@ -52,18 +40,6 @@ RUN dpkg -i mongodb-org-server_4.2.2_amd64.deb
 RUN git clone "https://$GH_PAT@github.com/JoinColony/colonyServer.git"
 WORKDIR /colonyServer
 RUN if [ ! -z "$COMMIT_HASH" ]; then git checkout $COMMIT_HASH; fi
-
-# Setup the environment variables
-RUN echo "DB_NAME=colonyCentralizedMetadata\n" \
-  "DB_URL=mongodb://127.0.0.1:27017\n" \
-  "DISABLE_EXPIRY_CHECK=$DISABLE_EXPIRY_CHECK\n" \
-  "DISABLE_AUTH_CHECK=$DISABLE_AUTH_CHECK\n" \
-  "JWT_SECRET=$JWT_SECRET\n" \
-  "NETWORK=$NETWORK\n" \
-  "NETWORK_CONTRACT_ADDRESS=$NETWORK_CONTRACT_ADDRESS\n" \
-  "INFURA_ID=$INFURA_ID\n" \
-  "APOLLO_PORT=$APOLLO_PORT\n" \
-  "ETHPLORER_API_KEY=$ETHPLORER_API_KEY\n" > .env
 
 # Setup the server modules
 RUN npm i


### PR DESCRIPTION
As the title says, this PR refactors the `app` and `server` docker image to remove the build time ENV arguments that were passed in at build time _(otherwise falling back to a default)_

This is no longer required as we set those values inside the kubernetes configuration, meaning we can use the same built image for multiple deployments and environments, without a need to re-build it.